### PR TITLE
Fixed bug where mappers nested inside other mappers are not generated

### DIFF
--- a/compiler-plugin/src/main/kotlin/tech/mappie/resolving/MappingResolver.kt
+++ b/compiler-plugin/src/main/kotlin/tech/mappie/resolving/MappingResolver.kt
@@ -50,13 +50,17 @@ class MappingResolver : BaseVisitor<Map<IrFunction, List<Mapping>>, MappieDefini
     }
 
     override fun visitClass(declaration: IrClass, data: MappieDefinitions): Map<IrFunction, List<Mapping>> {
+        val nested = declaration.declarations
+            .filterIsInstance<IrClass>().map { it.accept(data) }
+            .fold(mapOf(), Map<IrFunction, List<Mapping>>::plus)
+
         return if (declaration.accept(ShouldTransformCollector(declaration.fileEntry), Unit)) {
             declaration.declarations
-                .filter { it is IrClass || it is IrFunction }
+                .filterIsInstance<IrFunction>()
                 .map { it.accept(data) }
-                .fold(mapOf(), Map<IrFunction, List<Mapping>>::plus)
+                .fold(nested, Map<IrFunction, List<Mapping>>::plus)
         } else {
-            emptyMap()
+            nested
         }
     }
 

--- a/compiler-plugin/src/test/kotlin/tech/mappie/testing/MapperClassCanContainAllDeclarationsTest.kt
+++ b/compiler-plugin/src/test/kotlin/tech/mappie/testing/MapperClassCanContainAllDeclarationsTest.kt
@@ -67,5 +67,4 @@ class MapperClassCanContainAllDeclarationsTest {
                 .isEqualTo(Output("test"))
         }
     }
-
 }

--- a/compiler-plugin/src/test/kotlin/tech/mappie/testing/MapperClassInsideOtherDeclarationTest.kt
+++ b/compiler-plugin/src/test/kotlin/tech/mappie/testing/MapperClassInsideOtherDeclarationTest.kt
@@ -1,0 +1,50 @@
+package tech.mappie.testing
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import tech.mappie.testing.compilation.KotlinCompilation
+import tech.mappie.testing.compilation.KotlinCompilation.ExitCode
+import tech.mappie.testing.compilation.SourceFile.Companion.kotlin
+import java.io.File
+
+class MapperClassInsideOtherDeclarationTest {
+
+    data class Input(val text: String)
+    data class Output(val text: String)
+
+    @TempDir
+    lateinit var directory: File
+
+    @Test
+    fun `mapper can be declared nested`() {
+        KotlinCompilation(directory).apply {
+            sources = buildList {
+                add(
+                    kotlin("Test.kt",
+                        """
+                        import tech.mappie.api.ObjectMappie
+                        import tech.mappie.testing.MapperClassInsideOtherDeclarationTest.*
+
+                        class Thing {
+                            class Mapper : ObjectMappie<Input, Output>()                            
+                        }
+                        """
+                    )
+                )
+            }
+        }.compile {
+            assertThat(exitCode).isEqualTo(ExitCode.OK)
+            assertThat(messages).isEmpty()
+
+            val mapper = classLoader
+                .loadObjectMappieClass<Input, Output>("Thing\$Mapper")
+                .constructors
+                .first()
+                .call()
+
+            assertThat(mapper.map(Input("test")))
+                .isEqualTo(Output("test"))
+        }
+    }
+}

--- a/website/src/changelog.md
+++ b/website/src/changelog.md
@@ -6,6 +6,7 @@ changelog:
       title: "v0.7.0"
       items:
         - "Added more built-in mappers."
+        - "Fixed a bug where mappers nested inside classes which are not a mapper are not generated."
     - date: "2024-08-31"
       title: "v0.6.0"
       items:


### PR DESCRIPTION
Fixed bug where mappers nested inside classes which are not inheriting from a mappie mapper are not generated.