### PR TITLE
Removed deprecated method 'parameter(String)'

### DIFF
--- a/compiler-plugin/src/main/kotlin/tech/mappie/resolving/classes/ExplicitClassMappingCollector.kt
+++ b/compiler-plugin/src/main/kotlin/tech/mappie/resolving/classes/ExplicitClassMappingCollector.kt
@@ -118,7 +118,7 @@ private class TargetNameCollector(private val context: ResolverContext) : BaseVi
 
     override fun visitCall(expression: IrCall, data: Unit): Name {
         return when (expression.symbol.owner.name) {
-            IDENTIFIER_PARAMETER, IDENTIFIER_TO -> {
+            IDENTIFIER_TO -> {
                 val value = expression.valueArguments.first()!!
                 return if (value.isConstantLike && value is IrConst<*>) {
                     Name.identifier(value.value as String)

--- a/compiler-plugin/src/main/kotlin/tech/mappie/util/Identifiers.kt
+++ b/compiler-plugin/src/main/kotlin/tech/mappie/util/Identifiers.kt
@@ -22,8 +22,6 @@ val IDENTIFIER_FROM_VALUE = Name.identifier("fromValue")
 
 val IDENTIFIER_FROM_EXPRESSION = Name.identifier("fromExpression")
 
-val IDENTIFIER_PARAMETER = Name.identifier("parameter")
-
 val IDENTIFIER_TO = Name.identifier("to")
 
 val IDENTIFIER_TRANSFORM = Name.identifier("transform")

--- a/compiler-plugin/src/test/kotlin/tech/mappie/testing/objects/ConstructorParameterNotAFieldTest.kt
+++ b/compiler-plugin/src/test/kotlin/tech/mappie/testing/objects/ConstructorParameterNotAFieldTest.kt
@@ -36,7 +36,7 @@ class ConstructorParameterNotAFieldTest {
     
                         class Mapper : ObjectMappie<Input, Output>() {
                             override fun map(from: Input) = mapping {
-                                parameter("fake") fromProperty Input::input
+                                to("fake") fromProperty Input::input
                             }
                         }
                         """
@@ -61,7 +61,7 @@ class ConstructorParameterNotAFieldTest {
     
                         class Mapper : ObjectMappie<Input, Output>() {
                             override fun map(from: Input) = mapping {
-                                parameter(0.toString()) fromProperty Input::input
+                                to(0.toString()) fromProperty Input::input
                             }
                         }
                         """

--- a/mappie-api/src/commonMain/kotlin/tech/mappie/api/ObjectMappingConstructors.kt
+++ b/mappie-api/src/commonMain/kotlin/tech/mappie/api/ObjectMappingConstructors.kt
@@ -54,19 +54,6 @@ public class ObjectMappingConstructor<FROM, out TO> {
         generated()
 
     /**
-     * Reference a constructor parameter in lieu of a property reference, if it not exists as a property.
-     *
-     * For example
-     * ```kotlin
-     * parameter("name") fromProperty PersonDto::fullName
-     * ```
-     * will generate an explicit mapping, setting constructor parameter `name` to `PersonDto.fullName`.
-     */
-    @Deprecated("Replace with to", ReplaceWith("to(name)"))
-    public fun parameter(name: String): KProperty<*> =
-        generated()
-
-    /**
      * Reference a constructor parameter or target property in lieu of a property reference, if it not exists as a property.
      *
      * For example
@@ -115,19 +102,6 @@ public class MultipleObjectMappingConstructor<out TO> {
      * will generate an explicit mapping, setting constructor parameter `Person.name` to `"John Doe"`.
      */
     public infix fun <TO_TYPE> KProperty<TO_TYPE>.fromValue(value: TO_TYPE): Unit =
-        generated()
-
-    /**
-     * Reference a constructor parameter in lieu of a property reference, if it not exists as a property.
-     *
-     * For example
-     * ```kotlin
-     * parameter("name") fromProperty PersonDto::fullName
-     * ```
-     * will generate an explicit mapping, setting constructor parameter `name` to `PersonDto.fullName`.
-     */
-    @Deprecated("Replace with to", ReplaceWith("to(name)"))
-    public fun parameter(name: String): KProperty<*> =
         generated()
 
     /**

--- a/website/src/changelog.md
+++ b/website/src/changelog.md
@@ -2,6 +2,10 @@
 title: "Changelog"
 layout: "layouts/changelog.html"
 changelog:
+    - date: "tbd"
+      title: "v0.9.0"
+      items:
+        - "[#101](https://github.com/Mr-Mappie/mappie/issues/101) removed deprecated method 'parameter(String)'"
     - date: "2024-09-22"
       title: "v0.8.0"
       items:


### PR DESCRIPTION
Fixes issue #101 

Removed the method 'parameter(String)' from mappie api/src/commonMain/kotlin/tech/mappie/api/ObjectMappingConstructors.kt
Implementation from both classes, i.e., 'ObjectMappingConstructor' and 'MultipleObjectMappingConstructor' was removed.

Also updated the mappie website changelog for this issue, while naming the version as '0.9.0' and date as 'tbd'