### PR TITLE
fromExpression for ObjectMappieX

### DIFF
--- a/compiler-plugin/src/main/kotlin/tech/mappie/MappiePluginContext.kt
+++ b/compiler-plugin/src/main/kotlin/tech/mappie/MappiePluginContext.kt
@@ -25,5 +25,8 @@ fun MappieContext.referenceEnumMappieClass(): IrClassSymbol =
 fun MappieContext.referenceFunctionLet() =
     pluginContext.referenceFunctions(CallableId(FqName("kotlin"), Name.identifier("let"))).first()
 
+fun MappieContext.referenceFunctionRun() =
+    pluginContext.referenceFunctions(CallableId(FqName("kotlin"), Name.identifier("run"))).first()
+
 fun MappieContext.referenceFunctionRequireNotNull() =
     pluginContext.referenceFunctions(CallableId(FqName("kotlin"), Name.identifier("requireNotNull"))).first()

--- a/compiler-plugin/src/main/kotlin/tech/mappie/generation/classes/ObjectMappieCodeGenerator.kt
+++ b/compiler-plugin/src/main/kotlin/tech/mappie/generation/classes/ObjectMappieCodeGenerator.kt
@@ -13,6 +13,7 @@ import tech.mappie.generation.CodeGenerationContext
 import tech.mappie.generation.constructTransformation
 import tech.mappie.referenceFunctionLet
 import tech.mappie.referenceFunctionRequireNotNull
+import tech.mappie.referenceFunctionRun
 import tech.mappie.resolving.classes.sources.*
 import tech.mappie.resolving.classes.targets.FunctionCallTarget
 import tech.mappie.resolving.classes.targets.SetterTarget
@@ -42,7 +43,7 @@ class ObjectMappieCodeGenerator(private val context: CodeGenerationContext, priv
                     is SetterTarget -> {
                         +irCall(target.value.setter!!).apply {
                             dispatchReceiver = irGet(variable)
-                            putValueArgument(0, constructArgument(source ,model.declaration.valueParameters))
+                            putValueArgument(0, constructArgument(source, model.declaration.valueParameters))
                         }
                     }
                     is FunctionCallTarget -> {
@@ -80,9 +81,15 @@ class ObjectMappieCodeGenerator(private val context: CodeGenerationContext, priv
                 source.transformation?.let { constructTransformation(this@ObjectMappieCodeGenerator.context, it, getter) } ?: getter
             }
             is ExpressionMappingSource -> {
-                irCall(this@ObjectMappieCodeGenerator.context.referenceFunctionLet()).apply {
-                    extensionReceiver = irGet(parameters.single())
-                    putValueArgument(0, source.expression)
+                if (parameters.size == 1) {
+                    irCall(this@ObjectMappieCodeGenerator.context.referenceFunctionLet()).apply {
+                        extensionReceiver = irGet(parameters.single())
+                        putValueArgument(0, source.expression)
+                    }
+                } else {
+                    irCall(this@ObjectMappieCodeGenerator.context.referenceFunctionRun()).apply {
+                        putValueArgument(0, source.expression)
+                    }
                 }
             }
             is ValueMappingSource -> {

--- a/compiler-plugin/src/main/kotlin/tech/mappie/resolving/classes/sources/ClassMappingSource.kt
+++ b/compiler-plugin/src/main/kotlin/tech/mappie/resolving/classes/sources/ClassMappingSource.kt
@@ -77,7 +77,7 @@ data class ValueMappingSource(val expression: IrExpression) : ExplicitClassMappi
 }
 
 data class ExpressionMappingSource(val expression: IrExpression) : ExplicitClassMappingSource {
-    override val type = (expression.type as IrSimpleType).arguments[1].typeOrFail
+    override val type = (expression.type as IrSimpleType).arguments.last().typeOrFail
     override val origin = expression
 }
 

--- a/compiler-plugin/src/test/kotlin/tech/mappie/testing/objects/FromExpressionTest.kt
+++ b/compiler-plugin/src/test/kotlin/tech/mappie/testing/objects/FromExpressionTest.kt
@@ -4,6 +4,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import tech.mappie.testing.compilation.compile
+import tech.mappie.testing.loadObjectMappie2Class
 import tech.mappie.testing.loadObjectMappieClass
 import java.io.File
 
@@ -40,6 +41,36 @@ class FromExpressionTest {
                 .call()
 
             assertThat(mapper.map(Unit)).isEqualTo(Output(Unit::class.simpleName!!))
+        }
+    }
+
+    @Test
+    fun `map property fromExpression should succeed for ObjectMappie2`() {
+        compile(directory) {
+            file(
+                "Test.kt",
+                """
+                import tech.mappie.api.ObjectMappie2
+                import tech.mappie.testing.objects.FromExpressionTest.*
+
+                class Mapper : ObjectMappie2<Unit, Unit, Output>() {
+                    override fun map(from1: Unit, from2: Unit) = mapping {
+                        Output::value fromExpression { from1::class.simpleName!! as String }
+                    }
+                }
+                """
+            )
+        } satisfies {
+            isOk()
+            hasNoMessages()
+
+            val mapper = classLoader
+                .loadObjectMappie2Class<Unit, Unit, Output>("Mapper")
+                .constructors
+                .first()
+                .call()
+
+            assertThat(mapper.map(Unit, Unit)).isEqualTo(Output(Unit::class.simpleName!!))
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.9.2
+version=0.9.3

--- a/mappie-api/src/commonMain/kotlin/tech/mappie/api/ObjectMappingConstructors.kt
+++ b/mappie-api/src/commonMain/kotlin/tech/mappie/api/ObjectMappingConstructors.kt
@@ -123,6 +123,22 @@ public class MultipleObjectMappingConstructor<out TO> {
         generated()
 
     /**
+     * Explicitly construct a mapping to [TO] from expression source [function].
+     *
+     * For example
+     * ```kotlin
+     * override fun map(personDto: PersonDto, carDto: CarDto) = mapping {
+     *     PersonDto::name fromExpression { personDto.fullName + " (full) driving a " + carDto.name }
+     * ...
+     * }
+     * ```
+     * will generate an explicit mapping, setting constructor parameter `Person.name` to `"John Doe (full) driving a Smart"`,
+     * assuming `personDto.fullName == "John Doe"` and `carDto.name == "Smart"`.
+     */
+    public infix fun <FROM_TYPE, TO_TYPE> KProperty<TO_TYPE>.fromExpression(function: () -> FROM_TYPE): Unit =
+        generated()
+
+    /**
      * Reference a constructor parameter or target property in lieu of a property reference, if it not exists as a property.
      *
      * For example


### PR DESCRIPTION
Generates `kotlin.run` rather than `kotlin.let` in order to allow `fromExpression` in `Object{2,3,4,5}Mappie`