### PR TITLE
improved performance of merge() utils

### DIFF
--- a/compiler-plugin/src/main/kotlin/tech/mappie/util/MapExtensions.kt
+++ b/compiler-plugin/src/main/kotlin/tech/mappie/util/MapExtensions.kt
@@ -1,8 +1,12 @@
 package tech.mappie.util
 
-fun <K, V> List<Map<K, V>>.merge(): Map<K, V> = fold(emptyMap(), Map<K, V>::plus)
+fun <K, V> List<Map<K, V>>.merge(): Map<K, V> = buildMap {
+    this@merge.forEach { putAll(it) }
+}
 
-fun <K, V> Sequence<Map<K, V>>.merge(): Map<K, V> = fold(emptyMap(), Map<K, V>::plus)
+fun <K, V> Sequence<Map<K, V>>.merge(): Map<K, V> = buildMap {
+    this@merge.forEach { putAll(it) }
+}
 
 fun <K, V> Map<K, List<V>>.filterSingle(): Map<K, V> =
     filter { it.value.size == 1 }.mapValues { (_, v) -> v.single() }


### PR DESCRIPTION
original implementation was O(N*M), suggested implementation is O(N):

| map count | map size | old impl (ms) | new impl (ms) |
|---:|---:|---:|---:|
| 1 | 1 | 0.007 | 0.011 |
| 1 | 10 | 0.012 | 0.019 |
| 1 | 100 | 0.049 | 0.153 |
| 10 | 1 | 0.069 | 0.041 |
| 10 | 10 | 0.894 | 0.393 |
| 10 | 100 | 1.337 | 0.708 |
| 100 | 1 | 0.567 | 0.366 |
| 100 | 10 | 7.517 | 0.115 |
| 100 | 100 | 16.504 | 0.567 |
| 1000 | 1 | 9.843 | 0.061 |
| 1000 | 10 | 102.620 | 0.501 |
| 1000 | 100 | 3308.650 | 11.912 |