### PR TITLE
add missing dependencies label to dependabot for github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,3 +33,5 @@ updates:
     schedule:
       interval: "weekly"
       day: "friday"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
PRs for gradle and npm ecosystem contain the "dependencies" label but missing for github actions ecosystem