### PR TITLE
Add cooldown period for npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "friday"
+    cooldown:
+      default-days: 3
     groups:
       npm:
         patterns:


### PR DESCRIPTION
There are more and more supply chain attacks by infecting npm dependencies. Most large attacks are detected within hours. Adding a 3 day cooldown is a good balance between quickly adapting for security updates and allowing compromised releases to be identified.